### PR TITLE
#79: added inactive status to hid_access field for operations

### DIFF
--- a/sites/all/modules/hr/hr_operations/hr_operations.features.field_base.inc
+++ b/sites/all/modules/hr/hr_operations/hr_operations.features.field_base.inc
@@ -121,6 +121,7 @@ function hr_operations_field_default_field_bases() {
       'allowed_values' => array(
         'open' => 'Open (individuals in this contact list may be viewed by all HID users)',
         'closed' => 'Closed (individuals in this contact list may only be viewed by verified responders)',
+        'inactive' => 'Inactive (will not show up on HID)',
       ),
       'allowed_values_function' => '',
       'entity_translation_sync' => FALSE,

--- a/sites/all/modules/hr/hr_operations/hr_operations.features.field_base.inc
+++ b/sites/all/modules/hr/hr_operations/hr_operations.features.field_base.inc
@@ -17,14 +17,6 @@ function hr_operations_field_default_field_bases() {
     'deleted' => 0,
     'entity_types' => array(),
     'field_name' => 'field_cluster_configuration',
-    'foreign keys' => array(
-      'node' => array(
-        'columns' => array(
-          'target_id' => 'nid',
-        ),
-        'table' => 'node',
-      ),
-    ),
     'indexes' => array(
       'target_id' => array(
         0 => 'target_id',
@@ -62,14 +54,6 @@ function hr_operations_field_default_field_bases() {
     'deleted' => 0,
     'entity_types' => array(),
     'field_name' => 'field_country',
-    'foreign keys' => array(
-      'taxonomy_term_data' => array(
-        'columns' => array(
-          'target_id' => 'tid',
-        ),
-        'table' => 'taxonomy_term_data',
-      ),
-    ),
     'indexes' => array(
       'target_id' => array(
         0 => 'target_id',
@@ -171,14 +155,6 @@ function hr_operations_field_default_field_bases() {
     'deleted' => 0,
     'entity_types' => array(),
     'field_name' => 'field_operation_region',
-    'foreign keys' => array(
-      'node' => array(
-        'columns' => array(
-          'target_id' => 'nid',
-        ),
-        'table' => 'node',
-      ),
-    ),
     'indexes' => array(
       'target_id' => array(
         0 => 'target_id',

--- a/sites/all/modules/hr/hr_operations/hr_operations.features.field_instance.inc
+++ b/sites/all/modules/hr/hr_operations/hr_operations.features.field_instance.inc
@@ -660,6 +660,7 @@ function hr_operations_field_default_field_instances() {
     'label' => 'Social media',
     'required' => 0,
     'settings' => array(
+      'absolute_url' => 1,
       'attributes' => array(
         'class' => '',
         'configurable_title' => 0,
@@ -781,6 +782,7 @@ function hr_operations_field_default_field_instances() {
     'label' => 'Website',
     'required' => 0,
     'settings' => array(
+      'absolute_url' => 1,
       'attributes' => array(
         'class' => '',
         'configurable_title' => 0,

--- a/sites/all/modules/hr/hr_operations/hr_operations.views_default.inc
+++ b/sites/all/modules/hr/hr_operations/hr_operations.views_default.inc
@@ -149,16 +149,6 @@ function hr_operations_views_default_views() {
   $handler->display->display_options['cache']['output_lifespan'] = '21600';
   $handler->display->display_options['cache']['output_lifespan_custom'] = '0';
   $handler->display->display_options['defaults']['style_plugin'] = FALSE;
-  $handler->display->display_options['style_plugin'] = 'views_geojson';
-  $handler->display->display_options['style_options']['data_source']['value'] = 'wkt';
-  $handler->display->display_options['style_options']['data_source']['latitude'] = 'field_website_1';
-  $handler->display->display_options['style_options']['data_source']['longitude'] = 'field_website_1';
-  $handler->display->display_options['style_options']['data_source']['geofield'] = 'field_geofield';
-  $handler->display->display_options['style_options']['data_source']['wkt'] = 'field_geofield';
-  $handler->display->display_options['style_options']['data_source']['name_field'] = 'title_field';
-  $handler->display->display_options['style_options']['data_source']['description_field'] = 'nothing';
-  $handler->display->display_options['style_options']['jsonp_prefix'] = '';
-  $handler->display->display_options['style_options']['using_views_api_mode'] = 0;
   $handler->display->display_options['defaults']['style_options'] = FALSE;
   $handler->display->display_options['defaults']['row_plugin'] = FALSE;
   $handler->display->display_options['defaults']['row_options'] = FALSE;
@@ -411,6 +401,7 @@ function hr_operations_views_default_views() {
     t('Home pane'),
     t('All Operations'),
   );
+
   $export['hr_operations'] = $view;
 
   return $export;

--- a/sites/all/modules/hr/hr_operations/hr_operations.views_default.inc
+++ b/sites/all/modules/hr/hr_operations/hr_operations.views_default.inc
@@ -149,8 +149,10 @@ function hr_operations_views_default_views() {
   $handler->display->display_options['cache']['output_lifespan'] = '21600';
   $handler->display->display_options['cache']['output_lifespan_custom'] = '0';
   $handler->display->display_options['defaults']['style_plugin'] = FALSE;
+  $handler->display->display_options['style_plugin'] = 'default';
   $handler->display->display_options['defaults']['style_options'] = FALSE;
   $handler->display->display_options['defaults']['row_plugin'] = FALSE;
+  $handler->display->display_options['row_plugin'] = 'fields';
   $handler->display->display_options['defaults']['row_options'] = FALSE;
   $handler->display->display_options['defaults']['relationships'] = FALSE;
   /* Relationship: Entity Reference: Referenced Entity */


### PR DESCRIPTION
Instead of creating another field for this, I reused the hid_access field, and added the "inactive" status, so HID will have to pull any operation that does not have "hid_access = inactive"