### PR TITLE
Martin #282 map filter

### DIFF
--- a/sites/all/modules/hr/hr_search/hr_search.install
+++ b/sites/all/modules/hr/hr_search/hr_search.install
@@ -1,0 +1,23 @@
+<?php
+/**
+ * @file
+ * Update file for the Search feature.
+ */
+
+/**
+ * Re enables field_infographic_type field under search api fields.
+ */
+
+function hr_search_update_7001() {
+  $index = search_api_index_load('default_node_index', TRUE);
+
+  $fields = array(
+    'options' => $index->options,
+  );
+
+  $fields['options']['fields']['field_infographic_type'] = array(
+    'type' => 'integer',
+    'entity_type' => 'taxonomy_term',
+  );
+  search_api_index_edit($index->id, $fields);
+}


### PR DESCRIPTION
Re enables 'field_infographic_type' under search api fields. When indexing is performed, the required facet 'Filter by Map/Infographic Type' will be enabled.

Reverting the hr_search feature results in the search listings to fail. For instance the page at /documents, /en/operations/iraq/documents, /operations/iraq/infographics.