### PR TITLE
Small fixes to hr-document

### DIFF
--- a/sites/all/modules/hr/hr_documents/hr_documents.features.field_base.inc
+++ b/sites/all/modules/hr/hr_documents/hr_documents.features.field_base.inc
@@ -117,6 +117,9 @@ function hr_documents_field_default_field_bases() {
     'deleted' => 0,
     'entity_types' => array(),
     'field_name' => 'field_files_collection',
+    'field_permissions' => array(
+      'type' => 0,
+    ),
     'indexes' => array(
       'revision_id' => array(
         0 => 'revision_id',

--- a/sites/all/modules/hr/hr_documents/hr_documents.features.field_instance.inc
+++ b/sites/all/modules/hr/hr_documents/hr_documents.features.field_instance.inc
@@ -192,7 +192,7 @@ function hr_documents_field_default_field_instances() {
     'bundle' => 'hr_document',
     'default_value' => NULL,
     'deleted' => 0,
-    'description' => '',
+    'description' => 'Try to always include here the text of the document (like the entire press release or the executive summary in case of lengthy publications). If no text is available add a description of the file(s) you are publishing.',
     'display' => array(
       'default' => array(
         'label' => 'above',
@@ -217,21 +217,22 @@ function hr_documents_field_default_field_instances() {
     'entity_type' => 'node',
     'field_name' => 'body',
     'label' => 'Body',
-    'required' => FALSE,
+    'required' => 0,
     'settings' => array(
-      'display_summary' => FALSE,
+      'display_summary' => 0,
       'entity_translation_sync' => FALSE,
       'text_processing' => 1,
       'user_register_form' => FALSE,
     ),
     'widget' => array(
+      'active' => 1,
       'module' => 'text',
       'settings' => array(
         'rows' => 20,
         'summary_rows' => 5,
       ),
       'type' => 'text_textarea_with_summary',
-      'weight' => 13,
+      'weight' => 14,
     ),
   );
 
@@ -241,7 +242,7 @@ function hr_documents_field_default_field_instances() {
     'default_value' => NULL,
     'default_value_function' => 'entityreference_prepopulate_field_default_value',
     'deleted' => 0,
-    'description' => '',
+    'description' => 'Indicate the cluster(s)/sector(s) the document refers to.',
     'display' => array(
       'default' => array(
         'label' => 'above',
@@ -272,6 +273,7 @@ function hr_documents_field_default_field_instances() {
     'settings' => array(
       'behaviors' => array(
         'og_widget' => array(
+          'access_override' => 0,
           'admin' => array(
             'widget_type' => 'options_select',
           ),
@@ -284,7 +286,10 @@ function hr_documents_field_default_field_instances() {
           'action' => 'none',
           'action_on_edit' => 0,
           'fallback' => 'none',
-          'og_context' => 0,
+          'providers' => array(
+            'og_context' => 0,
+            'url' => 1,
+          ),
           'skip_perm' => 0,
           'status' => 1,
         ),
@@ -297,7 +302,7 @@ function hr_documents_field_default_field_instances() {
       'module' => 'og',
       'settings' => array(),
       'type' => 'og_complex',
-      'weight' => 5,
+      'weight' => 8,
     ),
   );
 
@@ -307,7 +312,7 @@ function hr_documents_field_default_field_instances() {
     'default_value' => NULL,
     'default_value_function' => '',
     'deleted' => 0,
-    'description' => '',
+    'description' => 'Click on the field and select the coordination hub(s) the document refers to (if any).',
     'display' => array(
       'default' => array(
         'label' => 'above',
@@ -351,7 +356,7 @@ function hr_documents_field_default_field_instances() {
         'apply_chosen' => 1,
       ),
       'type' => 'options_select',
-      'weight' => 8,
+      'weight' => 9,
     ),
   );
 
@@ -361,7 +366,7 @@ function hr_documents_field_default_field_instances() {
     'default_value' => NULL,
     'default_value_function' => '',
     'deleted' => 0,
-    'description' => '',
+    'description' => 'Click on the field and select the disaster(s) the document is about.',
     'display' => array(
       'default' => array(
         'label' => 'above',
@@ -405,17 +410,17 @@ function hr_documents_field_default_field_instances() {
         'apply_chosen' => 1,
       ),
       'type' => 'options_select',
-      'weight' => 9,
+      'weight' => 10,
     ),
   );
 
   // Exported field_instance: 'node-hr_document-field_document_type'
   $field_instances['node-hr_document-field_document_type'] = array(
     'bundle' => 'hr_document',
-    'default_value' => NULL,
+    'default_value' => array(),
     'default_value_function' => '',
     'deleted' => 0,
-    'description' => 'Try to always include here the text of the document (like the entire press release or the executive summary in case of lengthy publications). If no text is available add a description of the file(s) you are publishing.',
+    'description' => '',
     'display' => array(
       'default' => array(
         'label' => 'above',
@@ -472,7 +477,7 @@ function hr_documents_field_default_field_instances() {
         ),
       ),
       'type' => 'options_select',
-      'weight' => 1,
+      'weight' => 2,
     ),
   );
 
@@ -481,7 +486,7 @@ function hr_documents_field_default_field_instances() {
     'bundle' => 'hr_document',
     'default_value' => NULL,
     'deleted' => 0,
-    'description' => '',
+    'description' => 'Attach the file to publish and specify the language of the document from the drop-down menu. It is best to publish only one file per record.',
     'display' => array(
       'default' => array(
         'label' => 'above',
@@ -529,7 +534,7 @@ function hr_documents_field_default_field_instances() {
       'module' => 'field_collection',
       'settings' => array(),
       'type' => 'field_collection_embed',
-      'weight' => 2,
+      'weight' => 3,
     ),
   );
 
@@ -539,7 +544,7 @@ function hr_documents_field_default_field_instances() {
     'default_value' => NULL,
     'default_value_function' => '',
     'deleted' => 0,
-    'description' => '',
+    'description' => 'Click on the field and select the funding appeal the document refers to. Use this field only when the document is substantively related to a specific funding.',
     'display' => array(
       'default' => array(
         'label' => 'above',
@@ -583,7 +588,7 @@ function hr_documents_field_default_field_instances() {
         'apply_chosen' => 1,
       ),
       'type' => 'options_select',
-      'weight' => 10,
+      'weight' => 12,
     ),
   );
 
@@ -593,7 +598,7 @@ function hr_documents_field_default_field_instances() {
     'default_value' => NULL,
     'default_value_function' => '',
     'deleted' => 0,
-    'description' => '',
+    'description' => 'Select from the menu the country(ies) the document is about. You can add more specific locations by selecting multiple layers (region, province, town).',
     'display' => array(
       'default' => array(
         'label' => 'above',
@@ -619,7 +624,7 @@ function hr_documents_field_default_field_instances() {
     ),
     'entity_type' => 'node',
     'field_name' => 'field_locations',
-    'label' => 'Locations',
+    'label' => 'Location(s)',
     'required' => 0,
     'settings' => array(
       'behaviors' => array(
@@ -653,10 +658,10 @@ function hr_documents_field_default_field_instances() {
   // Exported field_instance: 'node-hr_document-field_organizations'
   $field_instances['node-hr_document-field_organizations'] = array(
     'bundle' => 'hr_document',
-    'default_value' => array(),
+    'default_value' => NULL,
     'default_value_function' => '',
     'deleted' => 0,
-    'description' => '',
+    'description' => 'Type and select the source(s) of the document.',
     'display' => array(
       'default' => array(
         'label' => 'above',
@@ -685,7 +690,7 @@ function hr_documents_field_default_field_instances() {
     ),
     'entity_type' => 'node',
     'field_name' => 'field_organizations',
-    'label' => 'Organization',
+    'label' => 'Organization(s)',
     'required' => 1,
     'settings' => array(
       'behaviors' => array(
@@ -781,7 +786,7 @@ function hr_documents_field_default_field_instances() {
         'year_range' => '-10:+0',
       ),
       'type' => 'date_select',
-      'weight' => 3,
+      'weight' => 4,
     ),
   );
 
@@ -790,7 +795,7 @@ function hr_documents_field_default_field_instances() {
     'bundle' => 'hr_document',
     'default_value' => NULL,
     'deleted' => 0,
-    'description' => '',
+    'description' => 'You can add links to related content (example: language versions of the same document, or the link of the event the meeting minutes refer to) by adding the title of the content and its url.',
     'display' => array(
       'default' => array(
         'label' => 'above',
@@ -820,6 +825,7 @@ function hr_documents_field_default_field_instances() {
       'absolute_url' => 1,
       'attributes' => array(
         'class' => '',
+        'configurable_class' => 0,
         'configurable_title' => 0,
         'rel' => '',
         'target' => '_blank',
@@ -836,7 +842,7 @@ function hr_documents_field_default_field_instances() {
       ),
       'rel_remove' => 'default',
       'title' => 'required',
-      'title_label_use_field_label' => FALSE,
+      'title_label_use_field_label' => 0,
       'title_maxlength' => 128,
       'title_value' => '',
       'url' => 0,
@@ -848,7 +854,7 @@ function hr_documents_field_default_field_instances() {
       'module' => 'link',
       'settings' => array(),
       'type' => 'link_field',
-      'weight' => 14,
+      'weight' => 15,
     ),
   );
 
@@ -902,7 +908,7 @@ function hr_documents_field_default_field_instances() {
         'apply_chosen' => 1,
       ),
       'type' => 'options_select',
-      'weight' => 4,
+      'weight' => 5,
     ),
   );
 
@@ -912,7 +918,7 @@ function hr_documents_field_default_field_instances() {
     'default_value' => NULL,
     'default_value_function' => '',
     'deleted' => 0,
-    'description' => '',
+    'description' => 'Click on the field and select all relevant themes. Choose only themes the document substantively refers to.',
     'display' => array(
       'default' => array(
         'label' => 'above',
@@ -959,7 +965,7 @@ function hr_documents_field_default_field_instances() {
         'apply_chosen' => 1,
       ),
       'type' => 'options_select',
-      'weight' => 12,
+      'weight' => 13,
     ),
   );
 
@@ -972,7 +978,7 @@ function hr_documents_field_default_field_instances() {
       ),
     ),
     'deleted' => 0,
-    'description' => '',
+    'description' => 'This field allows use to choose whether the document will be public, private or will keep the same setting of the group.',
     'display' => array(
       'default' => array(
         'label' => 'above',
@@ -997,7 +1003,7 @@ function hr_documents_field_default_field_instances() {
     'entity_type' => 'node',
     'field_name' => 'group_content_access',
     'label' => 'Group content visibility',
-    'required' => TRUE,
+    'required' => 1,
     'settings' => array(
       'entity_translation_sync' => FALSE,
       'user_register_form' => FALSE,
@@ -1013,12 +1019,13 @@ function hr_documents_field_default_field_instances() {
       ),
     ),
     'widget' => array(
+      'active' => 1,
       'module' => 'options',
       'settings' => array(
         'apply_chosen' => 0,
       ),
       'type' => 'options_select',
-      'weight' => 15,
+      'weight' => 16,
     ),
     'widget_type' => 'options_select',
   );
@@ -1029,7 +1036,7 @@ function hr_documents_field_default_field_instances() {
     'default_value' => NULL,
     'default_value_function' => 'entityreference_prepopulate_field_default_value',
     'deleted' => 0,
-    'description' => '',
+    'description' => 'Select the space where you want the document to be published.',
     'display' => array(
       'default' => array(
         'label' => 'above',
@@ -1057,6 +1064,7 @@ function hr_documents_field_default_field_instances() {
     'settings' => array(
       'behaviors' => array(
         'og_widget' => array(
+          'access_override' => 0,
           'admin' => array(
             'widget_type' => 'entityreference_autocomplete',
           ),
@@ -1070,6 +1078,7 @@ function hr_documents_field_default_field_instances() {
           'action_on_edit' => 0,
           'fallback' => 'form_error',
           'providers' => array(
+            'og_context' => 0,
             'url' => 1,
           ),
           'skip_perm' => 'administer modules',
@@ -1096,7 +1105,7 @@ function hr_documents_field_default_field_instances() {
       'module' => 'og',
       'settings' => array(),
       'type' => 'og_complex',
-      'weight' => 16,
+      'weight' => 17,
     ),
   );
 
@@ -1105,7 +1114,7 @@ function hr_documents_field_default_field_instances() {
     'bundle' => 'hr_document',
     'default_value' => NULL,
     'deleted' => 0,
-    'description' => '',
+    'description' => 'Type the original title of the document.',
     'display' => array(
       'default' => array(
         'label' => 'above',
@@ -1134,23 +1143,28 @@ function hr_documents_field_default_field_instances() {
     'entity_type' => 'node',
     'field_name' => 'title_field',
     'label' => 'Title',
-    'required' => TRUE,
+    'required' => 1,
     'settings' => array(
       'entity_translation_sync' => FALSE,
       'hide_label' => array(
-        'entity' => FALSE,
-        'page' => FALSE,
+        'entity' => 0,
+        'page' => 0,
+      ),
+      'linkit' => array(
+        'enable' => 0,
+        'insert_plugin' => '',
       ),
       'text_processing' => 0,
       'user_register_form' => FALSE,
     ),
     'widget' => array(
+      'active' => 1,
       'module' => 'text',
       'settings' => array(
         'size' => 60,
       ),
       'type' => 'text_textfield',
-      'weight' => 0,
+      'weight' => 1,
     ),
   );
 
@@ -1272,7 +1286,12 @@ function hr_documents_field_default_field_instances() {
   // Translatables
   // Included for use with string extractors like potx.
   t('Acronym');
+  t('Attach the file to publish and specify the language of the document from the drop-down menu. It is best to publish only one file per record.');
   t('Body');
+  t('Click on the field and select all relevant themes. Choose only themes the document substantively refers to.');
+  t('Click on the field and select the coordination hub(s) the document refers to (if any).');
+  t('Click on the field and select the disaster(s) the document is about.');
+  t('Click on the field and select the funding appeal the document refers to. Use this field only when the document is substantively related to a specific funding.');
   t('Clusters/Sectors');
   t('Coordination hubs');
   t('Description');
@@ -1284,16 +1303,24 @@ function hr_documents_field_default_field_instances() {
   t('Fundings');
   t('Global Clusters');
   t('Group content visibility');
+  t('Indicate the cluster(s)/sector(s) the document refers to.');
   t('Indicate when the document has originally been published.');
   t('Language');
-  t('Locations');
+  t('Location(s)');
   t('Name');
-  t('Organization');
+  t('Organization(s)');
   t('Original Publication Date');
   t('Related content');
+  t('Select from the menu the country(ies) the document is about. You can add more specific locations by selecting multiple layers (region, province, town).');
+  t('Select the space where you want the document to be published.');
   t('Space(s)');
   t('Themes');
+  t('This field allows use to choose whether the document will be public, private or will keep the same setting of the group.');
   t('Title');
+  t('Try to always include here the text of the document (like the entire press release or the executive summary in case of lengthy publications). If no text is available add a description of the file(s) you are publishing.');
+  t('Type and select the source(s) of the document.');
+  t('Type the original title of the document.');
+  t('You can add links to related content (example: language versions of the same document, or the link of the event the meeting minutes refer to) by adding the title of the content and its url.');
 
   return $field_instances;
 }

--- a/sites/all/modules/hr/hr_documents/hr_documents.strongarm.inc
+++ b/sites/all/modules/hr/hr_documents/hr_documents.strongarm.inc
@@ -106,16 +106,16 @@ function hr_documents_strongarm() {
           'weight' => '-5',
         ),
         'path' => array(
-          'weight' => '17',
-        ),
-        'redirect' => array(
           'weight' => '18',
         ),
+        'redirect' => array(
+          'weight' => '19',
+        ),
         'language' => array(
-          'weight' => '-10',
+          'weight' => '0',
         ),
         'flag' => array(
-          'weight' => '10',
+          'weight' => '11',
         ),
       ),
       'display' => array(

--- a/sites/all/modules/hr/hr_documents/hr_documents.views_default.inc
+++ b/sites/all/modules/hr/hr_documents/hr_documents.views_default.inc
@@ -134,7 +134,7 @@ function hr_documents_views_default_views() {
   $handler->display->display_options['fields']['field_organizations']['link_to_entity'] = 0;
   $handler->display->display_options['fields']['field_organizations']['view_mode'] = 'full';
   $handler->display->display_options['fields']['field_organizations']['bypass_access'] = 0;
-  /* Field: Indexed Node: Original Publication Date */
+  /* Field: Indexed Node: Publication Date */
   $handler->display->display_options['fields']['field_publication_date']['id'] = 'field_publication_date';
   $handler->display->display_options['fields']['field_publication_date']['table'] = 'search_api_index_default_node_index';
   $handler->display->display_options['fields']['field_publication_date']['field'] = 'field_publication_date';
@@ -290,7 +290,7 @@ function hr_documents_views_default_views() {
   $handler->display->display_options['fields']['field_organizations']['link_to_entity'] = 0;
   $handler->display->display_options['fields']['field_organizations']['view_mode'] = 'full';
   $handler->display->display_options['fields']['field_organizations']['bypass_access'] = 0;
-  /* Field: Indexed Node: Original Publication Date */
+  /* Field: Indexed Node: Publication Date */
   $handler->display->display_options['fields']['field_publication_date']['id'] = 'field_publication_date';
   $handler->display->display_options['fields']['field_publication_date']['table'] = 'search_api_index_default_node_index';
   $handler->display->display_options['fields']['field_publication_date']['field'] = 'field_publication_date';
@@ -418,7 +418,7 @@ function hr_documents_views_default_views() {
     'title_link' => 'content',
     'title_class' => '',
   );
-  /* Field: Indexed Node: Original Publication Date */
+  /* Field: Indexed Node: Publication Date */
   $handler->display->display_options['fields']['field_publication_date']['id'] = 'field_publication_date';
   $handler->display->display_options['fields']['field_publication_date']['table'] = 'search_api_index_default_node_index';
   $handler->display->display_options['fields']['field_publication_date']['field'] = 'field_publication_date';
@@ -515,7 +515,7 @@ function hr_documents_views_default_views() {
     'title_link' => 'content',
     'title_class' => '',
   );
-  /* Field: Indexed Node: Original Publication Date */
+  /* Field: Indexed Node: Publication Date */
   $handler->display->display_options['fields']['field_publication_date']['id'] = 'field_publication_date';
   $handler->display->display_options['fields']['field_publication_date']['table'] = 'search_api_index_default_node_index';
   $handler->display->display_options['fields']['field_publication_date']['field'] = 'field_publication_date';
@@ -600,7 +600,7 @@ function hr_documents_views_default_views() {
     t('Title'),
     t('Document type'),
     t('Organization'),
-    t('Original Publication Date'),
+    t('Publication Date'),
     t('Files'),
     t('All'),
     t('Search Documents'),
@@ -647,7 +647,7 @@ function hr_documents_views_default_views() {
   $handler->display->display_options['fields']['title']['label'] = '';
   $handler->display->display_options['fields']['title']['alter']['word_boundary'] = FALSE;
   $handler->display->display_options['fields']['title']['alter']['ellipsis'] = FALSE;
-  /* Sort criterion: Content: Publication Date (field_publication_date) */
+  /* Sort criterion: Content: Original Publication Date (field_publication_date) */
   $handler->display->display_options['sorts']['field_publication_date_value']['id'] = 'field_publication_date_value';
   $handler->display->display_options['sorts']['field_publication_date_value']['table'] = 'field_data_field_publication_date';
   $handler->display->display_options['sorts']['field_publication_date_value']['field'] = 'field_publication_date_value';
@@ -973,7 +973,7 @@ function hr_documents_views_default_views() {
   $handler->display->display_options['row_plugin'] = 'fields';
   $handler->display->display_options['defaults']['row_options'] = FALSE;
   $handler->display->display_options['defaults']['sorts'] = FALSE;
-  /* Sort criterion: Content: Publication Date (field_publication_date) */
+  /* Sort criterion: Content: Original Publication Date (field_publication_date) */
   $handler->display->display_options['sorts']['field_publication_date_value']['id'] = 'field_publication_date_value';
   $handler->display->display_options['sorts']['field_publication_date_value']['table'] = 'field_data_field_publication_date';
   $handler->display->display_options['sorts']['field_publication_date_value']['field'] = 'field_publication_date_value';
@@ -1066,7 +1066,7 @@ function hr_documents_views_default_views() {
   $handler->display->display_options['row_plugin'] = 'fields';
   $handler->display->display_options['defaults']['row_options'] = FALSE;
   $handler->display->display_options['defaults']['sorts'] = FALSE;
-  /* Sort criterion: Content: Publication Date (field_publication_date) */
+  /* Sort criterion: Content: Original Publication Date (field_publication_date) */
   $handler->display->display_options['sorts']['field_publication_date_value']['id'] = 'field_publication_date_value';
   $handler->display->display_options['sorts']['field_publication_date_value']['table'] = 'field_data_field_publication_date';
   $handler->display->display_options['sorts']['field_publication_date_value']['field'] = 'field_publication_date_value';


### PR DESCRIPTION
- Clusters/Sectors: move on top of Coordination hubs
- Locations: Change name to Location(s)
- Change to Organization(s)

- Title: Type the original title of the document
- FIle(s): Attach the file to publish and specify the language of the document from the drop-down menu. It is best to publish only one file per record.
- Clusters/Sectors: Indicate the cluster(s)/sector(s) the document refers to.
- Location(s): Select from the menu the country(ies) the document is about. You can add more specific locations by selecting multiple layers (region, province, town).
- Organization(s): Type and select the source(s) of the document.
- Coordination hub: Click on the field and select the coordination hub(s) the document refers to (if any).
- Disasters: Click on the field and select the disaster(s) the document is about.
- Funding: Click on the field and select the funding appeal the document refers to. Use this field only when the document is substantively related to a specific funding.
- Themes: Click on the field and select all relevant themes. Choose only themes the document substantively refers to.
- Related Content: You can add links to related content (example: language versions of the same document, or the link of the event the meeting minutes refer to) by adding the title of the content and its url.
- Group content visibility: This field allows use to choose whether the document will be public, private or will keep the same setting of the group.
- Space(s): Select the space where you want the document to be published.