### PR TITLE
Fixed footer link

### DIFF
--- a/sites/all/themes/humanitarianresponse/template.php
+++ b/sites/all/themes/humanitarianresponse/template.php
@@ -100,7 +100,7 @@ function humanitarianresponse_preprocess_page(&$variables) {
   ));
 
   if (user_is_anonymous()) {
-    $variables['follow_us_link_href'] = 'user/login';
+    $variables['follow_us_link_href'] = 'connect/oauthconnector_hid_oauth';
     $variables['follow_us_link_title'] = t('Login to follow us');
     $variables['follow_us_link_status'] = 'flag';
   }

--- a/sites/all/themes/humanitarianresponse/templates/system/page.tpl.php
+++ b/sites/all/themes/humanitarianresponse/templates/system/page.tpl.php
@@ -159,7 +159,7 @@
       <i class="fa fa-question-circle"></i> <a href="mailto:help@humanitarianresponse.info">help@humanitarianresponse.info</a><br />
       <i class="fa fa-info-circle"></i> <?php print l('humanitarianresponse.info', '<front>'); ?><br />
       <i class="fa fa-rss-square"></i> <?php print l(t('RSS feed'), 'feed'); ?><br />
-      <i class="fa <?php ($follow_us_link_status == 'flag') ? print 'fa-check' : print 'fa-times'; ?>"></i> <a href="<?php print $follow_us_link_href; ?>"><?php print $follow_us_link_title; ?></a>
+      <i class="fa <?php ($follow_us_link_status == 'flag') ? print 'fa-check' : print 'fa-times'; ?>"></i> <?php print l($follow_us_link_title, $follow_us_link_href, array('attributes' => array('rel' => 'nofollow'))); ?>
     </div>
   </div>
 </footer>


### PR DESCRIPTION
Fixed the footer link, which was generated as user/login and which robots were following, generating URLs such as https://www.humanitarianresponse.info/es/operations/ecuador/events/print/17026/2016-09/user/login?field_bundles_target_id_entityreference_filter=124037&field_coordination_hubs_target_id_entityreference_filter=All&field_event_category_target_id_entityreference_filter=82&field_location_target_id_entityreference_filter=All which are causing pgsql errors.