### PR TITLE
[OPS-1870] [OPS-1871] Add new environments to environment_indicator.

### DIFF
--- a/sites/all/modules/hr/hr_core/hr_core.install
+++ b/sites/all/modules/hr/hr_core/hr_core.install
@@ -268,3 +268,46 @@ function hr_core_update_7015() {
     _hr_core_display_cache_content_defaults('none', $margin = 5, $type);
   }
 }
+
+/**
+ * Enable environment indicator for new test sites.
+ */
+function hr_core_update_7016() {
+  // Add assessmentregistry.
+  if (!ctools_export_crud_load('environment_indicator_environment', 'hr_assessmentregistry')) {
+    $environment = ctools_export_crud_new('environment_indicator_environment', TRUE);
+    $environment->api_version = 1;
+    $environment->disabled = FALSE;
+    $environment->machine = 'hr_assessmentregistry';
+    $environment->name = t('HR Assessment Registry');
+    $environment->regexurl = 'assessmentregistry.hrinfo.568elmp03.blackmesh.com';
+    $environment->settings = array(
+      'color' => '#a40071',
+      'text_color' => '#ffffff',
+      'weight' => 99,
+      'position' => 'top',
+      'fixed' => FALSE,
+    );
+
+    ctools_export_crud_save('environment_indicator_environment', $environment);
+  }
+
+  // Add indicatorregistry.
+  if (!ctools_export_crud_load('environment_indicator_environment', 'hr_indicatorregistry')) {
+    $environment = ctools_export_crud_new('environment_indicator_environment', TRUE);
+    $environment->api_version = 1;
+    $environment->disabled = FALSE;
+    $environment->machine = 'hr_indicatorregistry';
+    $environment->name = t('HR Indicator Registry');
+    $environment->regexurl = 'indicatorregistry.hrinfo.568elmp03.blackmesh.com';
+    $environment->settings = array(
+      'color' => '#017585',
+      'text_color' => '#ffffff',
+      'weight' => 99,
+      'position' => 'top',
+      'fixed' => FALSE,
+    );
+
+    ctools_export_crud_save('environment_indicator_environment', $environment);
+  }
+}

--- a/sites/all/modules/hr/hr_core/hr_core.install
+++ b/sites/all/modules/hr/hr_core/hr_core.install
@@ -284,7 +284,7 @@ function hr_core_update_7016() {
     $environment->settings = array(
       'color' => '#a40071',
       'text_color' => '#ffffff',
-      'weight' => 99,
+      'weight' => 90,
       'position' => 'top',
       'fixed' => FALSE,
     );
@@ -303,11 +303,21 @@ function hr_core_update_7016() {
     $environment->settings = array(
       'color' => '#017585',
       'text_color' => '#ffffff',
-      'weight' => 99,
+      'weight' => 91,
       'position' => 'top',
       'fixed' => FALSE,
     );
 
     ctools_export_crud_save('environment_indicator_environment', $environment);
   }
+
+  // Update staging, ensure the regex only matches the main test environment.
+  $environment = ctools_export_crud_load('environment_indicator_environment', 'hr_test');
+  $environment->regexurl = '^(www.)?hrinfo.568elmp03.blackmesh.com';
+  ctools_export_crud_save('environment_indicator_environment', $environment);
+
+  // Update default, since the first regex match is applied. This should always be listed last.
+  $environment = ctools_export_crud_load('environment_indicator_environment', 'default_environment');
+  $environment->settings['weight'] = 100;
+  ctools_export_crud_save('environment_indicator_environment', $environment);
 }


### PR DESCRIPTION
Adds a deep purple profile for assessment and a dark teal for indicator.

This would need to be separately merged into each of the feature branches.

I am 99% sure that environment_indicator will apply the match with the lightest weight, so the default should be last. I've tightened up the hr_test regex, so it doesn't automagically apply to any unconfigured environment on mp03.