### PR TITLE
HRINFO-641 changed innerText to innerHTML to prevent firefox bug 

### DIFF
--- a/sites/all/modules/hr/hr_reliefweb/js/hr_reliefweb_overview.js
+++ b/sites/all/modules/hr/hr_reliefweb/js/hr_reliefweb_overview.js
@@ -83,7 +83,7 @@
         var option = options[j];
         var newOption = document.createElement('option');
         newOption.value = option.href;
-        newOption.text = option.innerText;
+        newOption.text = option.innerHTML;
         newSelect.appendChild(newOption);
       }
 


### PR DESCRIPTION
innerText returns any empty string here in Firefox causing the select to not be properly populated. Changing it to innerHTML fixes the issue and works in IE & Chrome as well.