### PR TITLE
[HOTFIX] PHP7 Fatal: break statement outside switch. Safe to remove.

### DIFF
--- a/sites/all/modules/contrib/j2h/j2h.module
+++ b/sites/all/modules/contrib/j2h/j2h.module
@@ -169,6 +169,5 @@ function j2h_block_view($delta = '') {
       $block['content'] = j2h('4w');
       return $block;
   }
-  break;
 }
 


### PR DESCRIPTION
This PR fixes a superfluous line of code that makes HR.info 503 on PHP 7.1.6. Without it, it runs fine.

On a different note, why is this module in contrib? It's custom, from github, and unmaintained.