### PR TITLE
[HOTFIX] Correctly use cache_set() and specify the bin, so we can retrieve the stored data.

### DIFF
--- a/sites/all/modules/contrib/j2h/j2h.module
+++ b/sites/all/modules/contrib/j2h/j2h.module
@@ -126,7 +126,7 @@ function j2h($mod_api='') {
       
       // Only cache real data.
       if ($json_data) {
-        cache_set($cache_id, $variables, REQUEST_TIME + 24 * 60 * 60);
+        cache_set($cache_id, $variables, 'cache', REQUEST_TIME + 24 * 60 * 60);
       }
     }
 


### PR DESCRIPTION
The module was not using the cache API correctly, so the data was never cached, which meant that cache_get never returned anything.