### PR TITLE
[OPS-3458] Custom (drush) module that can export all nodes selected by a view, with attached files.

### DIFF
--- a/sites/all/modules/private_content_export/private_content_export.drush.inc
+++ b/sites/all/modules/private_content_export/private_content_export.drush.inc
@@ -1,0 +1,30 @@
+<?php
+/**
+ * @file
+ */
+
+/**
+ * Implements hook_drush_help().
+ */
+function private_content_export_drush_help($section) {
+  switch ($section) {
+    case 'drush:private-content-export':
+      return dt('Export private content listed by the my_private_content::attachment_1 view.');
+  }
+}
+
+/**
+ * Implements hook_drush_command().
+ */
+function private_content_export_drush_command() {
+  $items = array();
+
+  $items['private-content-export'] = array(
+    'description' => 'Rebuild the node access table',
+    'callback' => 'private_content_export_export_content',
+    'bootstrap' => DRUSH_BOOTSTRAP_DRUPAL_FULL,
+    'aliases' => array('pce'),
+  );
+
+  return $items;
+}

--- a/sites/all/modules/private_content_export/private_content_export.info
+++ b/sites/all/modules/private_content_export/private_content_export.info
@@ -1,0 +1,4 @@
+name = Private Content Export
+description = Export private nodes and their file attachments in a useable format.
+core = 7.x
+version = 7.x-1.0

--- a/sites/all/modules/private_content_export/private_content_export.module
+++ b/sites/all/modules/private_content_export/private_content_export.module
@@ -1,0 +1,72 @@
+<?php
+/**
+ * @file
+ */
+
+define('PCE_EXPORT_ROOT', '/tmp/pce');
+
+/**
+ * Callback function to export content.
+ *
+ * Runs the code for the my-private-content view to obtain the list
+ * of nodes that should be exported.
+ */
+function private_content_export_export_content() {
+  // Hack root.
+  global $user;
+  $user = user_load(1);
+
+  $list = views_get_view_result('my_private_content', 'attachment_1');
+
+  drush_print(dt("Going to export @count items", array('@count' => count($list))));
+
+  foreach ($list as $item) {
+    // Where do we save this?
+    $group = $item->field_og_group_ref['0']['rendered']['#markup'];
+    if (!file_exists(PCE_EXPORT_ROOT . '/' . $group)) {
+      mkdir(PCE_EXPORT_ROOT . '/' . $group . '/files', 0755, TRUE);
+    }
+    $output = PCE_EXPORT_ROOT . '/' . $group . '/' . $node->nid . '.html';
+
+    drush_print(dt("Processing @nid", array('@nid' => $item->nid)));
+
+    // Render.
+    // Only save after we've rewritten the file links.
+    $node = node_load($item->nid);
+    $node_view = node_view($node);
+    $rendered_node = drupal_render($node_view);
+
+    if (!empty($node->field_files_collection[LANGUAGE_NONE])) {
+      // Copy attachments.
+      foreach ($node->field_files_collection[LANGUAGE_NONE] as $collection) {
+        $data = field_collection_item_load($collection['value']);
+
+        $file = file_load($data->field_file[LANGUAGE_NONE][0]['fid']);
+        if (file_copy($file, PCE_EXPORT_ROOT . '/' . $group . '/files/' . $file->filename, FILE_EXISTS_REPLACE)) {
+          drush_print(dt(" ✓ Wrote @file", array('@file' => $file->filename)));
+        }
+        else {
+          drush_print(dt(" ❌ Failed to write @file", array('@file' => $file->filename)));
+        }
+
+        // Fix the file path.
+        $search = dirname(file_create_url($file->uri));
+        $rendered_node = strtr($rendered_node, array($search => 'files'));
+      }
+    }
+
+    // Save.
+    file_put_contents($output, $rendered_node);
+    drush_print(dt("Processed '@title'", array('@nid' => $node->nid, '@title' => $node->title))); 
+  }
+}
+
+/**
+ * Implements hook_views_api()
+ */
+function private_content_export_views_api() {
+  return array(
+    'api'  => 3,
+    'path' => drupal_get_path('module', 'private_content_export') . '/views',
+  );
+}

--- a/sites/all/modules/private_content_export/views/private_content_export.views_default.inc
+++ b/sites/all/modules/private_content_export/views/private_content_export.views_default.inc
@@ -1,0 +1,191 @@
+<?php
+/**
+ * @file
+ */
+
+/**
+ * Implements hook_views_default_views()
+ */
+function private_content_export_views_default_views() {
+  $view = new view();
+  $view->name = 'my_private_content';
+  $view->description = '';
+  $view->tag = 'default';
+  $view->base_table = 'node';
+  $view->human_name = 'My Private Content';
+  $view->core = 7;
+  $view->api_version = '3.0';
+  $view->disabled = FALSE; /* Edit this to true to make a default view disabled initially */
+
+  /* Display: Master */
+  $handler = $view->new_display('default', 'Master', 'default');
+  $handler->display->display_options['title'] = 'My Private Content';
+  $handler->display->display_options['use_more_always'] = FALSE;
+  $handler->display->display_options['access']['type'] = 'role';
+  $handler->display->display_options['access']['role'] = array(
+    30037204 => '30037204',
+  );
+  $handler->display->display_options['cache']['type'] = 'none';
+  $handler->display->display_options['query']['type'] = 'views_query';
+  $handler->display->display_options['exposed_form']['type'] = 'basic';
+  $handler->display->display_options['pager']['type'] = 'full';
+  $handler->display->display_options['pager']['options']['items_per_page'] = '10';
+  $handler->display->display_options['style_plugin'] = 'table';
+  /* Relationship: Content: Author */
+  $handler->display->display_options['relationships']['uid']['id'] = 'uid';
+  $handler->display->display_options['relationships']['uid']['table'] = 'node';
+  $handler->display->display_options['relationships']['uid']['field'] = 'uid';
+  $handler->display->display_options['relationships']['uid']['required'] = TRUE;
+  /* Relationship: Content: File(s) (field_files_collection) */
+  $handler->display->display_options['relationships']['field_files_collection_value']['id'] = 'field_files_collection_value';
+  $handler->display->display_options['relationships']['field_files_collection_value']['table'] = 'field_data_field_files_collection';
+  $handler->display->display_options['relationships']['field_files_collection_value']['field'] = 'field_files_collection_value';
+  $handler->display->display_options['relationships']['field_files_collection_value']['label'] = 'Files';
+  $handler->display->display_options['relationships']['field_files_collection_value']['delta'] = '-1';
+  /* Field: Content: Type */
+  $handler->display->display_options['fields']['type']['id'] = 'type';
+  $handler->display->display_options['fields']['type']['table'] = 'node';
+  $handler->display->display_options['fields']['type']['field'] = 'type';
+  /* Field: Content: Nid */
+  $handler->display->display_options['fields']['nid']['id'] = 'nid';
+  $handler->display->display_options['fields']['nid']['table'] = 'node';
+  $handler->display->display_options['fields']['nid']['field'] = 'nid';
+  /* Field: Content: Author uid */
+  $handler->display->display_options['fields']['uid']['id'] = 'uid';
+  $handler->display->display_options['fields']['uid']['table'] = 'node';
+  $handler->display->display_options['fields']['uid']['field'] = 'uid';
+  /* Field: Content: Title */
+  $handler->display->display_options['fields']['title']['id'] = 'title';
+  $handler->display->display_options['fields']['title']['table'] = 'node';
+  $handler->display->display_options['fields']['title']['field'] = 'title';
+  $handler->display->display_options['fields']['title']['alter']['word_boundary'] = FALSE;
+  $handler->display->display_options['fields']['title']['alter']['ellipsis'] = FALSE;
+  /* Field: Content: Link */
+  $handler->display->display_options['fields']['view_node']['id'] = 'view_node';
+  $handler->display->display_options['fields']['view_node']['table'] = 'views_entity_node';
+  $handler->display->display_options['fields']['view_node']['field'] = 'view_node';
+  $handler->display->display_options['fields']['view_node']['alter']['alter_text'] = TRUE;
+  $handler->display->display_options['fields']['view_node']['alter']['text'] = 'https://humanitarianresponse.info/node/[nid]';
+  /* Field: Content: Content visibility */
+  $handler->display->display_options['fields']['group_content_access']['id'] = 'group_content_access';
+  $handler->display->display_options['fields']['group_content_access']['table'] = 'field_data_group_content_access';
+  $handler->display->display_options['fields']['group_content_access']['field'] = 'group_content_access';
+  /* Field: Content: Webspace(s) */
+  $handler->display->display_options['fields']['og_group_ref']['id'] = 'og_group_ref';
+  $handler->display->display_options['fields']['og_group_ref']['table'] = 'og_membership';
+  $handler->display->display_options['fields']['og_group_ref']['field'] = 'og_group_ref';
+  $handler->display->display_options['fields']['og_group_ref']['settings'] = array(
+    'bypass_access' => 0,
+    'link' => 0,
+  );
+  $handler->display->display_options['fields']['og_group_ref']['delta_offset'] = '0';
+  /* Field: Content: File(s) */
+  $handler->display->display_options['fields']['field_files_collection']['id'] = 'field_files_collection';
+  $handler->display->display_options['fields']['field_files_collection']['table'] = 'field_data_field_files_collection';
+  $handler->display->display_options['fields']['field_files_collection']['field'] = 'field_files_collection';
+  $handler->display->display_options['fields']['field_files_collection']['alter']['alter_text'] = TRUE;
+  $handler->display->display_options['fields']['field_files_collection']['alter']['text'] = '[field_files_collection]';
+  $handler->display->display_options['fields']['field_files_collection']['settings'] = array(
+    'edit' => '',
+    'delete' => '',
+    'add' => '',
+    'description' => 0,
+    'view_mode' => 'token',
+  );
+  $handler->display->display_options['fields']['field_files_collection']['delta_offset'] = '0';
+  /* Field: Realname: Real name */
+  $handler->display->display_options['fields']['realname']['id'] = 'realname';
+  $handler->display->display_options['fields']['realname']['table'] = 'realname';
+  $handler->display->display_options['fields']['realname']['field'] = 'realname';
+  $handler->display->display_options['fields']['realname']['relationship'] = 'uid';
+  /* Field: User: E-mail */
+  $handler->display->display_options['fields']['mail']['id'] = 'mail';
+  $handler->display->display_options['fields']['mail']['table'] = 'users';
+  $handler->display->display_options['fields']['mail']['field'] = 'mail';
+  $handler->display->display_options['fields']['mail']['relationship'] = 'uid';
+  /* Field: Field collection item: File */
+  $handler->display->display_options['fields']['field_file']['id'] = 'field_file';
+  $handler->display->display_options['fields']['field_file']['table'] = 'field_data_field_file';
+  $handler->display->display_options['fields']['field_file']['field'] = 'field_file';
+  $handler->display->display_options['fields']['field_file']['relationship'] = 'field_files_collection_value';
+  $handler->display->display_options['fields']['field_file']['label'] = 'Raw File';
+  $handler->display->display_options['fields']['field_file']['click_sort_column'] = 'fid';
+  $handler->display->display_options['fields']['field_file']['type'] = 'file_url_plain';
+  /* Sort criterion: Content: Post date */
+  $handler->display->display_options['sorts']['created']['id'] = 'created';
+  $handler->display->display_options['sorts']['created']['table'] = 'node';
+  $handler->display->display_options['sorts']['created']['field'] = 'created';
+  $handler->display->display_options['sorts']['created']['order'] = 'DESC';
+  /* Filter criterion: Content: Content visibility (group_content_access) */
+  $handler->display->display_options['filters']['group_content_access_value']['id'] = 'group_content_access_value';
+  $handler->display->display_options['filters']['group_content_access_value']['table'] = 'field_data_group_content_access';
+  $handler->display->display_options['filters']['group_content_access_value']['field'] = 'group_content_access_value';
+  $handler->display->display_options['filters']['group_content_access_value']['value'] = array(
+    2 => '2',
+  );
+  /* Filter criterion: Content: Type */
+  $handler->display->display_options['filters']['type']['id'] = 'type';
+  $handler->display->display_options['filters']['type']['table'] = 'node';
+  $handler->display->display_options['filters']['type']['field'] = 'type';
+  $handler->display->display_options['filters']['type']['exposed'] = TRUE;
+  $handler->display->display_options['filters']['type']['expose']['operator_id'] = 'type_op';
+  $handler->display->display_options['filters']['type']['expose']['label'] = 'Type';
+  $handler->display->display_options['filters']['type']['expose']['operator'] = 'type_op';
+  $handler->display->display_options['filters']['type']['expose']['identifier'] = 'type';
+  $handler->display->display_options['filters']['type']['expose']['remember_roles'] = array(
+    2 => '2',
+    1 => 0,
+    30037204 => 0,
+    200153887 => 0,
+    218860149 => 0,
+    188284353 => 0,
+    235660466 => 0,
+  );
+
+  /* Display: Page */
+  $handler = $view->new_display('page', 'Page', 'page');
+  $handler->display->display_options['path'] = 'admin/my-private-content';
+
+  /* Display: Data export */
+  $handler = $view->new_display('views_data_export', 'Data export', 'views_data_export_1');
+  $handler->display->display_options['pager']['type'] = 'some';
+  $handler->display->display_options['pager']['options']['items_per_page'] = '0';
+  $handler->display->display_options['pager']['options']['offset'] = '0';
+  $handler->display->display_options['style_plugin'] = 'views_data_export_csv';
+  $handler->display->display_options['path'] = 'admin/my-private-content.csv';
+  $handler->display->display_options['use_batch'] = 'batch';
+  $handler->display->display_options['segment_size'] = '100';
+
+  /* Display: Attachment */
+  $handler = $view->new_display('attachment', 'Attachment', 'attachment_1');
+  $handler->display->display_options['pager']['type'] = 'none';
+  $handler->display->display_options['pager']['options']['offset'] = '0';
+  $handler->display->display_options['defaults']['fields'] = FALSE;
+  /* Field: Content: Nid */
+  $handler->display->display_options['fields']['nid']['id'] = 'nid';
+  $handler->display->display_options['fields']['nid']['table'] = 'node';
+  $handler->display->display_options['fields']['nid']['field'] = 'nid';
+  $handler->display->display_options['defaults']['filter_groups'] = FALSE;
+  $handler->display->display_options['defaults']['filters'] = FALSE;
+  /* Field: Content: Webspace(s) */                                                                                                                                                   
+  $handler->display->display_options['fields']['og_group_ref']['id'] = 'og_group_ref';                                                                                                
+  $handler->display->display_options['fields']['og_group_ref']['table'] = 'og_membership';                                                                                            
+  $handler->display->display_options['fields']['og_group_ref']['field'] = 'og_group_ref';                                                                                             
+  $handler->display->display_options['fields']['og_group_ref']['settings'] = array(                                                                                                   
+    'bypass_access' => 0,                                                                                                                                                             
+    'link' => 0,                                                                                                                                                                      
+  );                                                                                                                                                                                  
+  $handler->display->display_options['fields']['og_group_ref']['delta_offset'] = '0';  
+  /* Filter criterion: Content: Content visibility (group_content_access) */
+  $handler->display->display_options['filters']['group_content_access_value']['id'] = 'group_content_access_value';
+  $handler->display->display_options['filters']['group_content_access_value']['table'] = 'field_data_group_content_access';
+  $handler->display->display_options['filters']['group_content_access_value']['field'] = 'group_content_access_value';
+  $handler->display->display_options['filters']['group_content_access_value']['value'] = array(
+    2 => '2',
+  );
+  $handler->display->display_options['filters']['group_content_access_value']['group'] = 1;
+
+  $views[$view->name] = $view;
+
+  return $views;
+}


### PR DESCRIPTION
Note that you need to revert the 'My Private Content' view after enabling this module, so that the attachment_1 display exists.