### PR TITLE
[OPS-3588] Bump the memory_limit to 1G for logged-in admin users, so …

### DIFF
--- a/sites/all/modules/hr/hr_admin/hr_admin.module
+++ b/sites/all/modules/hr/hr_admin/hr_admin.module
@@ -29,3 +29,14 @@ function hr_admin_menu() {
 
   return $items;
 }
+
+/**
+ * Implements hook_init().
+ */
+function hr_admin_init() {
+  // If the current user has administrative privileges, bump the
+  // memory limit, so that they can delete complex content.
+  if (user_access('access administration pages')) {
+    ini_set('memory_limit', '1024M');
+  }
+}


### PR DESCRIPTION
…they can delete complex content without help from ops.